### PR TITLE
Base constructor now takes request as third positional argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Development
 -----------
 
 - Fix issue #6: HTTP 500 error when using POST verb on Item resources.
+- Breaking changes:
+
+  - `royal.resource:Base` constructor now takes request as third positional
+    argument.
+  - `royal.resource:Base.resource_url` and `Base.url` method signatures change.
 
 0.7.4
 -----

--- a/example/resources/photos.py
+++ b/example/resources/photos.py
@@ -24,8 +24,8 @@ class Collection(royal.Collection):
 
 class Item(royal.Item):
 
-    def __init__(self, key, parent, document=None):
-        super(Item, self).__init__(key, parent)
+    def __init__(self, key, parent, request, document=None):
+        super(Item, self).__init__(key, parent, request)
         self.document = document
 
     def load_document(self):

--- a/example/resources/users.py
+++ b/example/resources/users.py
@@ -17,7 +17,8 @@ class Collection(royal.Collection):
         offset = params['offset']
         limit = params['limit']
         cursor = User.get_newests(self.root.db, offset, limit)
-        documents = [Item(user.username, self, user).show() for user in cursor]
+        documents = [Item(user.username, self, self.request, user).show()
+                     for user in cursor]
         result = {
             'users': documents,
             'href': self.url(offset=offset, limit=limit),
@@ -35,8 +36,8 @@ class Collection(royal.Collection):
 
 class Item(royal.Item):
 
-    def __init__(self, key, parent, document=None):
-        super(Item, self).__init__(key, parent)
+    def __init__(self, key, parent, request, document=None):
+        super(Item, self).__init__(key, parent, request)
         self.document = document
 
     def load_document(self):
@@ -64,7 +65,7 @@ class Item(royal.Item):
                             new_username=new_username,
                             new_email=new_email)
         Photo.replace_author(self.root.db, self.name, new_username)
-        new_item = Item(new_username, self.parent, user)
+        new_item = Item(new_username, self.parent, self.request, user)
         user['href'] = new_item.url()
         user['photos'] = {
             'href': new_item['photos'].url()

--- a/example/resources/users_photos.py
+++ b/example/resources/users_photos.py
@@ -20,8 +20,9 @@ class Collection(royal.Collection):
         limit = query_params['limit']
         cursor = Photo.get_newests(self.root.db, offset, limit,
                                    author=self.parent.name)
-        documents = [photos.Item(str(doc._id), self.root, doc).show()
-                     for doc in cursor]
+        documents = [
+            photos.Item(str(doc._id), self.root, self.request, doc).show()
+            for doc in cursor]
         result = {
             'photos': documents,
             'href': self.url(offset=offset, limit=limit),
@@ -41,4 +42,5 @@ class Collection(royal.Collection):
         author = unicode(self.parent.name)
         mime_type = mimetypes.guess_extension(fs.filename)
         doc = Photo.create(self.root.db, author, fs.file, mime_type)
-        return photos.Item(str(doc._id), self.root['photos'], doc)
+        return photos.Item(str(doc._id), self.root['photos'], self.request,
+                           doc)

--- a/royal/resource.py
+++ b/royal/resource.py
@@ -19,16 +19,17 @@ def includeme(config):
 @implementer(IBase)
 class Base(object):
 
-    def __init__(self, name, parent):
+    children = {}
+
+    def __init__(self, name, parent, request):
         self.__name__ = unicode(name)
         self.__parent__ = parent
-        if not hasattr(self, 'children'):
-            self.children = {}
+        self.request = request
 
     def __getitem__(self, key):
         key = unicode(key)
         self.on_traversing(key)
-        return self.children[key](key, self)
+        return self.children[key](key, self, self.request)
 
     def _not_allowed(self, name):
         raise exceptions.MethodNotAllowed(self, name)
@@ -61,15 +62,12 @@ class Base(object):
     def root(self):
         return find_root(self)
 
-    def resource_url(self, resource, request=None, **query_params):
+    def resource_url(self, resource, **query_params):
         kw = {'query': query_params}
-        if request is None:
-            request = self.root.request
-        return request.resource_url(resource, **kw)
+        return self.request.resource_url(resource, **kw)
 
-
-    def url(self, request=None, **query_params):
-        return self.resource_url(self, request, **query_params)
+    def url(self, **query_params):
+        return self.resource_url(self, **query_params)
 
     @property
     def parent(self):
@@ -81,7 +79,7 @@ class Base(object):
 
     @property
     def links(self):
-        _links = {name: {'href': cls(name, self).url()}
+        _links = {name: {'href': cls(name, self, self.request).url()}
                   for name, cls in self.children.iteritems()}
         _links['href'] = self.url()
         return _links
@@ -96,8 +94,7 @@ class Root(Base):
     request = None
 
     def __init__(self, request):
-        super(Root, self).__init__('', None)
-        self.request = request
+        super(Root, self).__init__('', None, request)
 
     def show(self, params):
         return self.links
@@ -114,5 +111,5 @@ class Collection(Base):
     def __getitem__(self, key):
         self.on_traversing(key)
         if hasattr(self, 'item_cls'):
-            return self.item_cls(key, self)
-        return self.children[key](key, self)
+            return self.item_cls(key, self, self.request)
+        return self.children[key](key, self, self.request)

--- a/royal/tests/unittests/test_resources.py
+++ b/royal/tests/unittests/test_resources.py
@@ -5,7 +5,7 @@ from pyramid.testing import DummyRequest
 class Test(unittest.TestCase):
 
     def check_assertions(self, cls, name, parent=None):
-        b = cls(name, parent)
+        b = cls(name, parent, None)
         if parent is None:
             root = b
         else:
@@ -47,7 +47,7 @@ class Test(unittest.TestCase):
         from royal.exceptions import MethodNotAllowed
         request = DummyRequest()
         root = Root(request)
-        c = Collection('users', root)
+        c = Collection('users', root, None)
         resource = self.check_assertions(Item, 'hadrien', parent=c)
 
         with self.assertRaises(MethodNotAllowed):

--- a/royal/utility.py
+++ b/royal/utility.py
@@ -21,14 +21,14 @@ def includeme(config):
 class ResourceDefinition(object):
     def __init__(self, resource_path, collection_cls, item_cls, parent,
                  name):
-        self.resource_path = resource_path
+        self.path = resource_path
         self.collection_cls = collection_cls
         self.item_cls = item_cls
         self.parent = parent
         self.name = name
 
     def __repr__(self):
-        return '<ResourceDefinition(%s)>' % self.resource_path
+        return '<ResourceDefinition(%s)>' % self.path
 
 
 @implementer(IResourceConfigurator)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyramid_royal
-version = 0.7.5-dev0
+version = 0.8.0-dev0
 author = Hadrien David
 author_email = hadrien+pypi@ectobal.com
 home_page = https://github.com/hadrien/pyramid_royal


### PR DESCRIPTION
- Breaking changes:

  - `royal.resource:Base` constructor now takes request as third positional
    argument.
  - `royal.resource:Base.resource_url` and `Base.url` method signatures change.