### PR TITLE
docs: Fix simple typo, extentsion -> extension

### DIFF
--- a/royal/tests/__init__.py
+++ b/royal/tests/__init__.py
@@ -21,7 +21,7 @@ def setupPackage():
     os.environ['MONGO_DB_NAME'] = 'royal_example'
     os.environ['MONGO_DB_PREFIX'] = ''
 
-    # sqla extentsion setup.
+    # sqla extension setup.
     global engine
 
     alembic_config = Config()


### PR DESCRIPTION
There is a small typo in royal/tests/__init__.py.

Should read `extension` rather than `extentsion`.

